### PR TITLE
docs: tune the RDT build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,13 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
-    nodejs: "16"
+    python: "3.10"
+    nodejs: "19"
+  jobs:
+    pre_install:
+      - pip install docutils==0.18.1
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+    nodejs: "16"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@ build:
     python: "3.10"
     nodejs: "19"
   jobs:
-    post_create_environment:
-      - pip uninstall sphinx-rtd-theme
+    pre_install:
+      - pip install sphinx==5.3.0
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@ build:
     python: "3.10"
     nodejs: "19"
   jobs:
-    pre_install:
-      - pip install docutils==0.18.1
+    post_create_environment:
+      - pip uninstall sphinx-rtd-theme
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
the build is prevented by rdt_sphinx_theme that we don't use and that is forced installed on rdt website. It doesn't support docutils 0.19 that is required somewhere. I'm reluctant to make a pin just for them.

ref: https://github.com/readthedocs/sphinx_rtd_theme/issues/1323