### PR TITLE
feat: use the fonts from the NPM distrib

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -67,16 +67,18 @@ Then for each icon role occurence an :code:`<i>` tag will be used:
 Latex output
 ------------
 
-In the latex outut the `fontawesome5 package <https://www.ctan.org/pkg/fontawesome5>`__ is added to the :code:`preamble`:
+For the latex output, the **sphinx-icon** extention need to use the webfonts provided by fontawesome. It will thus force the use of the XeLaTex builder to allow use of the `fontspec package <https://ctan.org/pkg/fontspec?lang=en>`__. Then 3 new font will be added to the preamble of the tex file:
 
-.. code-block:: Latex
+.. code-block:: latex
 
-    \usepackage{fontawesome5}
+    \newfontfamily{\solid}{fa-solid-900.ttf}
+    \newfontfamily{\regular}{fa-regular-400.ttf}
+    \newfontfamily{\brands}{fa-brands-400.ttf}
 
 Then for each icon role occurence the following command will be used:
 
 .. code-block:: latex
 
-    \faIcon[style]{the-icon-name}
+    {\solid\symbol{"F007}}
 
-with :code:`style` being one of "regular", "solid" or "brand" and :code:`the-icon-name` being everything after :code:`fa-`.
+where ``solid`` is the font style selected in the role and ``F007`` being the unicode of the selected icon.

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,14 +15,6 @@ def docs(session):
 
 
 @nox.session(reuse_venv=True)
-def docs_latex(session):
-    """Build the documentation."""
-    session.install(".[doc]")
-    b = session.posargs[0] if session.posargs else "latexpdf"
-    session.run("sphinx-build", "-M", f"{b}", "docs", f"docs/_build/{b}")
-
-
-@nox.session(reuse_venv=True)
 def lint(session):
     """Apply the pre-commits."""
     session.install("pre-commit")

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,14 @@ def docs(session):
 
 
 @nox.session(reuse_venv=True)
+def docs_latex(session):
+    """Build the documentation."""
+    session.install(".[doc]")
+    b = session.posargs[0] if session.posargs else "latexpdf"
+    session.run("sphinx-build", "-M", f"{b}", "docs", f"docs/_build/{b}")
+
+
+@nox.session(reuse_venv=True)
 def lint(session):
     """Apply the pre-commits."""
     session.install("pre-commit")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ packages = ["sphinxcontrib.icon"]
     "node_modules/**/all.min.css",
     "node_modules/**/all.min.js",
     "node_modules/**/icons.yml",
+    "node_modules/**/*.ttf",
     "package.json",
     "package-lock.json"
 ]

--- a/sphinxcontrib/icon/__init__.py
+++ b/sphinxcontrib/icon/__init__.py
@@ -14,10 +14,22 @@ __email__ = "pierrick.rambaud49@gmail.com"
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     """Add icon node to the sphinx builder."""
+    # load the icon node/role
     app.add_node(icon_node, **_NODE_VISITORS)  # type: ignore
     app.add_role("icon", Icon())
-    app.add_css_file(str(Fontawesome.css_file.resolve()))
-    app.add_js_file(str(Fontawesome.js_file.resolve()))
+
+    # load the font
+    font_handler = Fontawesome()
+
+    # install html related files
+    app.add_css_file(str(font_handler.css_file.resolve()))
+    app.add_js_file(str(font_handler.js_file.resolve()))
+
+    # install latex files
+    app.add_latex_package("fontspec")
+    app.connect("config-inited", font_handler.add_latex_font)
+    app.connect("config-inited", font_handler.enforce_xelatex)
+    app.connect("builder-inited", font_handler.add_latex_font_files)
 
     return {
         "version": __version__,

--- a/sphinxcontrib/icon/font_handler.py
+++ b/sphinxcontrib/icon/font_handler.py
@@ -51,7 +51,7 @@ class Fontawesome:
             dst = Path(app.builder.outdir) / f.name
             logger.info(f"Writing: {f.name}")
             ensuredir(app.builder.outdir)
-            copyfile(f, dst)
+            copyfile(str(f.resolve()), str(dst.resolve()))
 
     def add_latex_font(self, app: Sphinx, config: Config) -> None:
         """Add the fontawesome fontfamily in the preamble of the .tex file."""
@@ -71,4 +71,4 @@ class Fontawesome:
 
         Compulsory to access the fontspec package
         """
-        config.latex_engine = "xelatex"
+        config.latex_engine = "xelatex"  # type: ignore

--- a/sphinxcontrib/icon/font_handler.py
+++ b/sphinxcontrib/icon/font_handler.py
@@ -1,10 +1,17 @@
 """Handler to install the fontawesome resources in the build."""
 
 from pathlib import Path
+from textwrap import dedent
 
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.util import logging
+from sphinx.util.osutil import copyfile, ensuredir
 from yaml import safe_load
 
 HERE = Path(__file__).parent
+
+logger = logging.getLogger(__name__)
 
 
 class Fontawesome:
@@ -15,6 +22,7 @@ class Fontawesome:
     metadata = safe_load((fa_dir / "metadata" / "icons.yml").read_text())
     css_file = fa_dir / "css" / "all.min.css"
     js_file = fa_dir / "js" / "all.min.js"
+    webfont_folder = fa_dir / "webfonts"
     html_font = {
         "fa": "fa-solid",
         "fas": "fa-solid",
@@ -28,8 +36,39 @@ class Fontawesome:
         "fa": "solid",
         "fas": "solid",
         "far": "regular",
-        "fab": "brand",
+        "fab": "brands",
         "fa-solid": "solid",
         "fa-regular": "regular",
-        "fa-brands": "brand",
+        "fa-brands": "brands",
     }
+
+    def add_latex_font_files(self, app: Sphinx) -> None:
+        """Copy the fontawesome files to the build repository for latex build."""
+        if app.builder.name != "latex":
+            return
+
+        for f in self.webfont_folder.glob("*.ttf"):
+            dst = Path(app.builder.outdir) / f.name
+            logger.info(f"Writing: {f.name}")
+            ensuredir(app.builder.outdir)
+            copyfile(f, dst)
+
+    def add_latex_font(self, app: Sphinx, config: Config) -> None:
+        """Add the fontawesome fontfamily in the preamble of the .tex file."""
+        if "preamble" not in config.latex_elements:
+            config.latex_elements["preamble"] = ""
+
+        config.latex_elements["preamble"] += dedent(
+            r"""
+        \newfontfamily{\solid}{fa-solid-900.ttf}
+        \newfontfamily{\regular}{fa-regular-400.ttf}
+        \newfontfamily{\brands}{fa-brands-400.ttf}
+        """
+        )
+
+    def enforce_xelatex(self, app: Sphinx, config: Config) -> None:
+        """Force the builder to use the XeLaTex builder instead of vanilla Latex.
+
+        Compulsory to access the fontspec package
+        """
+        config.latex_engine = "xelatex"

--- a/sphinxcontrib/icon/icon.py
+++ b/sphinxcontrib/icon/icon.py
@@ -72,7 +72,7 @@ def visit_icon_node_latex(translator: SphinxTranslator, node: icon_node) -> None
     # build the output
     font = Fontawesome.latex_font[font]
     unicode = Fontawesome.metadata[glyph]["unicode"]
-    translator.body.append(f'{{\\{font}\\symbol{{"{unicode.upper()}}}}}')
+    translator.body.append(r'{\%s\symbol{"%s}}' % (font, unicode.upper()))
 
     return
 

--- a/sphinxcontrib/icon/icon.py
+++ b/sphinxcontrib/icon/icon.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 from docutils import nodes
 from sphinx.util import logging
-from sphinx.util.docutils import SphinxRole
+from sphinx.util.docutils import SphinxRole, SphinxTranslator
 
 from .font_handler import Fontawesome
 
@@ -50,45 +50,39 @@ def get_glyph(text) -> Tuple[str, str]:
     return m.group("font"), m.group("glyph")
 
 
-def depart_icon_node_html(self, node: icon_node) -> None:
+def depart_icon_node_html(translator: SphinxTranslator, node: icon_node) -> None:
     """Depart the html node."""
-    self.body.append("</i>")
+    translator.body.append("</i>")
     pass
 
 
-def visit_icon_node_html(self, node: icon_node) -> None:
+def visit_icon_node_html(translator: SphinxTranslator, node: icon_node) -> None:
     """Visit the html output."""
     font, glyph = get_glyph(node["icon"])
-    self.body.append(f'<i class="{Fontawesome.html_font[font]} fa-{glyph}">')
+    translator.body.append(f'<i class="{Fontawesome.html_font[font]} fa-{glyph}">')
 
     return
 
 
-def visit_icon_node_latex(self, node: icon_node) -> None:
+def visit_icon_node_latex(translator: SphinxTranslator, node: icon_node) -> None:
     """Visit the latex output."""
+    # extract info from the node
     font, glyph = get_glyph(node["icon"])
 
-    # detect the font
-    font = Fontawesome.latex_font[font]
-
-    # install fontawesome 5 package
-    package = "\\usepackage{fontawesome5}"
-    if package not in self.elements["preamble"]:
-        self.elements["preamble"] += f"{package}\n"
-
     # build the output
-    font_mark = f"[{font}]" if font else ""
-    self.body.append(f"\\faIcon{font_mark}{{{glyph}}}")
+    font = Fontawesome.latex_font[font]
+    unicode = Fontawesome.metadata[glyph]["unicode"]
+    translator.body.append(f'{{\\{font}\\symbol{{"{unicode.upper()}}}}}')
 
     return
 
 
-def depart_icon_node_latex(self, node: icon_node) -> None:
+def depart_icon_node_latex(translator: SphinxTranslator, node: icon_node) -> None:
     """Everything is done in the visit method."""
     pass
 
 
-def visit_icon_node_unsuported(self, node: icon_node) -> None:
+def visit_icon_node_unsuported(translator: SphinxTranslator, node: icon_node) -> None:
     """Raise error when the requested output is not supported."""
     logger.warning("Unsupported output format (node skipped)")
     raise nodes.SkipNode

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -22,10 +22,14 @@ def test_fa6_icon_latex(app, status, warning):
 
     result = (app.outdir / "test-icon.tex").read_text(encoding="utf8")
 
-    assert "\\usepackage{fontawesome5}" in result
-    assert "\\faIcon[solid]{folder}" in result
-    assert "\\faIcon[regular]{user}" in result
-    assert "\\faIcon[brand]{500px}" in result
+    assert r"\usepackage{fontspec}" in result
+    assert r"\newfontfamily{\solid}{fa-solid-900.ttf}" in result
+    assert r"\newfontfamily{\regular}{fa-regular-400.ttf}" in result
+    assert r"\newfontfamily{\brands}{fa-brands-400.ttf}" in result
+
+    assert r'{\solid\symbol{"F07B}}' in result
+    assert r'{\regular\symbol{"F007}}' in result
+    assert r'{\brands\symbol{"F26E}}' in result
 
 
 @pytest.mark.sphinx("latex", testroot="fa5-icon")
@@ -35,10 +39,9 @@ def test_fa5_icon_latex(app, status, warning):
 
     result = (app.outdir / "test-icon.tex").read_text(encoding="utf8")
 
-    assert "\\usepackage{fontawesome5}" in result
-    assert "\\faIcon[solid]{folder}" in result
-    assert "\\faIcon[regular]{user}" in result
-    assert "\\faIcon[brand]{500px}" in result
+    assert r'{\solid\symbol{"F07B}}' in result
+    assert r'{\regular\symbol{"F007}}' in result
+    assert r'{\brands\symbol{"F26E}}' in result
 
 
 @pytest.mark.sphinx("latex", testroot="fa4-icon")
@@ -48,8 +51,7 @@ def test_fa4_icon_latex(app, status, warning):
 
     result = (app.outdir / "test-icon.tex").read_text(encoding="utf8")
 
-    assert "\\usepackage{fontawesome5}" in result
-    assert "\\faIcon[solid]{folder}" in result
+    assert r'{\solid\symbol{"F07B}}' in result
 
 
 @pytest.mark.sphinx("html", testroot="fa6-icon")


### PR DESCRIPTION
Instead of relying on the fontawesome5 package for the latex build, we now add on the fly the .ttf font files available in the NPM distribution. These files are then added to the preamble:  

``` latex
\newfontfamily{\solid}{fa-solid-900.ttf}
\newfontfamily{\regular}{fa-regular-400.ttf}
\newfontfamily{\brands}{fa-brands-400.ttf}
```

and a custom cammand is run for every occurence of a icon role: 

```latex
{\solid\symbol{"F007}}
```

It ensures that the latex and html build are always on sync and Fix #4 