### PR TITLE
fix: accept aliases of icon names

### DIFF
--- a/sphinxcontrib/icon/font_handler.py
+++ b/sphinxcontrib/icon/font_handler.py
@@ -72,3 +72,25 @@ class Fontawesome:
         Compulsory to access the fontspec package
         """
         config.latex_engine = "xelatex"  # type: ignore
+
+    @classmethod
+    def search_alias(cls, icon_name: str) -> str:
+        """Search for the text in the potential aliases of fontawesome.
+
+        This method should only be called after checking the name against metadata to avoid
+        calling it for each icon.
+
+        Args:
+            icon_name: the name of the icon to search for. it should not be a label
+
+        Returns:
+            the name of the icon, empty string if not found
+        """
+        latest_name = ""
+        for label, meta in cls.metadata.items():
+            aliases = meta.get("aliases", {}).get("names", [])
+            if icon_name in aliases:
+                latest_name = label
+                break
+
+        return latest_name

--- a/sphinxcontrib/icon/icon.py
+++ b/sphinxcontrib/icon/icon.py
@@ -43,14 +43,13 @@ def get_glyph(text: str, location: Optional[Tuple[str, int]] = None) -> Tuple[st
         raise nodes.SkipNode
     font, glyph = m.group("font"), m.group("glyph")
     if font not in Fontawesome.html_font:
-        msg = f'font "{font}" is not part of fontawesome'
+        msg = f'font "{font}" is not part of fontawesome, ignoring'
         logger.warning(msg, location=location)
         raise nodes.SkipNode
     if glyph not in Fontawesome.metadata:
-        # check if it's not an alias
         latest_glyph = Fontawesome.search_alias(glyph)
         if latest_glyph == "":
-            msg = f'icon "{glyph}" is not part of fontawesome'
+            msg = f'icon "{glyph}" is not part of fontawesome, ignoring'
             logger.warning(msg, location=location)
             raise nodes.SkipNode
         else:

--- a/sphinxcontrib/icon/icon.py
+++ b/sphinxcontrib/icon/icon.py
@@ -41,16 +41,24 @@ def get_glyph(text: str, location: Optional[Tuple[str, int]] = None) -> Tuple[st
     if not m:
         logger.warning(f'invalid icon name: "{text}"', location=location)
         raise nodes.SkipNode
-    if m.group("font") not in Fontawesome.html_font:
-        msg = f'font "{m.group("font")}" is not part of fontawesome'
+    font, glyph = m.group("font"), m.group("glyph")
+    if font not in Fontawesome.html_font:
+        msg = f'font "{font}" is not part of fontawesome'
         logger.warning(msg, location=location)
         raise nodes.SkipNode
-    if m.group("glyph") not in Fontawesome.metadata:
-        msg = f'icon "{m.group("glyph")}" is not part of fontawesome'
-        logger.warning(msg, location=location)
-        raise nodes.SkipNode
+    if glyph not in Fontawesome.metadata:
+        # check if it's not an alias
+        latest_glyph = Fontawesome.search_alias(glyph)
+        if latest_glyph == "":
+            msg = f'icon "{glyph}" is not part of fontawesome'
+            logger.warning(msg, location=location)
+            raise nodes.SkipNode
+        else:
+            msg = f'icon "{glyph}" is an alias of "{latest_glyph}", replacing'
+            logger.warning(msg, location=location)
+            glyph = latest_glyph
 
-    return m.group("font"), m.group("glyph")
+    return font, glyph
 
 
 def depart_icon_node_html(translator: SphinxTranslator, node: icon_node) -> None:

--- a/sphinxcontrib/icon/icon.py
+++ b/sphinxcontrib/icon/icon.py
@@ -39,21 +39,21 @@ def get_glyph(text: str, location: Optional[Tuple[str, int]] = None) -> Tuple[st
     # split the icon name to find the name inside
     m = re.match(Fontawesome.regex, text)
     if not m:
-        logger.warning(f'invalid icon name: "{text}"', location=location)
+        logger.warning(f'Ignoring: invalid icon format: "{text}".', location=location)
         raise nodes.SkipNode
     font, glyph = m.group("font"), m.group("glyph")
     if font not in Fontawesome.html_font:
-        msg = f'font "{font}" is not part of fontawesome, ignoring'
+        msg = f'Ignoring: font "{font}" is not part of fontawesome.'
         logger.warning(msg, location=location)
         raise nodes.SkipNode
     if glyph not in Fontawesome.metadata:
         latest_glyph = Fontawesome.search_alias(glyph)
         if latest_glyph == "":
-            msg = f'icon "{glyph}" is not part of fontawesome, ignoring'
+            msg = f'ignoring: icon "{glyph}" is not part of fontawesome.'
             logger.warning(msg, location=location)
             raise nodes.SkipNode
         else:
-            msg = f'icon "{glyph}" is an alias of "{latest_glyph}", replacing'
+            msg = f'Replacing: icon "{glyph}" is an alias of "{latest_glyph}".'
             logger.warning(msg, location=location)
             glyph = latest_glyph
 

--- a/tests/roots/test-fa6-alias-icon/conf.py
+++ b/tests/roots/test-fa6-alias-icon/conf.py
@@ -1,0 +1,6 @@
+"""Configuration file for the Sphinx documentation builder."""
+
+project = "test-icon"
+extensions = ["sphinxcontrib.icon"]
+exclude_patterns = ["_build"]
+html_theme = "basic"

--- a/tests/roots/test-fa6-alias-icon/index.rst
+++ b/tests/roots/test-fa6-alias-icon/index.rst
@@ -1,0 +1,4 @@
+icon
+====
+
+I'm an :icon:`fa-solid fa-trash-alt` icon.

--- a/tests/roots/test-fa6-wrong-icon/conf.py
+++ b/tests/roots/test-fa6-wrong-icon/conf.py
@@ -1,0 +1,6 @@
+"""Configuration file for the Sphinx documentation builder."""
+
+project = "test-icon"
+extensions = ["sphinxcontrib.icon"]
+exclude_patterns = ["_build"]
+html_theme = "basic"

--- a/tests/roots/test-fa6-wrong-icon/index.rst
+++ b/tests/roots/test-fa6-wrong-icon/index.rst
@@ -1,0 +1,4 @@
+icon
+====
+
+I'm an :icon:`fa-solid fa-toto` icon.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -65,11 +65,11 @@ def test_fa6_icon_html(app, status, warning, file_regression):
     folder = html.select("i.fa-solid")[0].prettify(formatter=fmt)
     file_regression.check(folder, basename="folder_icon", extension=".html")
 
-    html.select("i.fa-regular")[0].prettify(formatter=fmt)
-    file_regression.check(folder, basename="pencil_icon", extension=".html")
+    pencil = html.select("i.fa-regular")[0].prettify(formatter=fmt)
+    file_regression.check(pencil, basename="pencil_icon", extension=".html")
 
-    html.select("i.fa-brands")[0].prettify(formatter=fmt)
-    file_regression.check(folder, basename="github_icon", extension=".html")
+    github = html.select("i.fa-brands")[0].prettify(formatter=fmt)
+    file_regression.check(github, basename="github_icon", extension=".html")
 
 
 @pytest.mark.sphinx("html", testroot="fa5-icon")
@@ -83,11 +83,11 @@ def test_fa5_icon_html(app, status, warning, file_regression):
     folder = html.select("i.fa-solid")[0].prettify(formatter=fmt)
     file_regression.check(folder, basename="folder_icon", extension=".html")
 
-    html.select("i.fa-regular")[0].prettify(formatter=fmt)
-    file_regression.check(folder, basename="pencil_icon", extension=".html")
+    pencil = html.select("i.fa-regular")[0].prettify(formatter=fmt)
+    file_regression.check(pencil, basename="pencil_icon", extension=".html")
 
-    html.select("i.fa-brands")[0].prettify(formatter=fmt)
-    file_regression.check(folder, basename="github_icon", extension=".html")
+    github = html.select("i.fa-brands")[0].prettify(formatter=fmt)
+    file_regression.check(github, basename="github_icon", extension=".html")
 
 
 @pytest.mark.sphinx("html", testroot="fa4-icon")
@@ -100,3 +100,25 @@ def test_fa4_icon_html(app, status, warning, file_regression):
 
     folder = html.select("i.fa-solid")[0].prettify(formatter=fmt)
     file_regression.check(folder, basename="folder_icon", extension=".html")
+
+
+@pytest.mark.sphinx("html", testroot="fa6-alias-icon")
+def test_fa6_alias_icon_html(app, status, warning, file_regression):
+    """Build an icon role in HTML using the trash-alt alias for trash-can."""
+    app.builder.build_all()
+
+    assert 'icon "trash-alt" is an alias of "trash-can"' in warning.getvalue()
+
+    html = (app.outdir / "index.html").read_text(encoding="utf8")
+    html = BeautifulSoup(html, "html.parser")
+
+    trash = html.select("i.fa-solid")[0].prettify(formatter=fmt)
+    file_regression.check(trash, basename="trash_can_icon", extension=".html")
+
+
+@pytest.mark.sphinx("html", testroot="fa6-wrong-icon")
+def test_fa6_wrong_icon_html(app, status, warning):
+    """Build an icon role in HTML using a non existing icon."""
+    app.builder.build_all()
+
+    assert 'icon "toto" is not part of fontawesome' in warning.getvalue()

--- a/tests/test_build/github_icon.html
+++ b/tests/test_build/github_icon.html
@@ -1,2 +1,2 @@
-<i class="fa-solid fa-folder">
+<i class="fa-brands fa-500px">
 </i>

--- a/tests/test_build/pencil_icon.html
+++ b/tests/test_build/pencil_icon.html
@@ -1,2 +1,2 @@
-<i class="fa-solid fa-folder">
+<i class="fa-regular fa-user">
 </i>

--- a/tests/test_build/trash_can_icon.html
+++ b/tests/test_build/trash_can_icon.html
@@ -1,0 +1,2 @@
+<i class="fa-solid fa-trash-can">
+</i>


### PR DESCRIPTION
Fix #23 

- search for aliases names in the Fontawesome object 
- init the search only if the font is not found 
- raise a warning if the icon is an alias 
- use the real name to change as few code as possible
- add tests for wrong and alias icons 
- test were always testing folder and not the other icons