### PR TITLE
fix: include woff2 fonts in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ packages = ["sphinxcontrib.icon"]
     "node_modules/**/all.min.js",
     "node_modules/**/icons.yml",
     "node_modules/**/*.ttf",
+    "node_modules/**/*.woff2",
     "package.json",
     "package-lock.json"
 ]


### PR DESCRIPTION
According to my web logs the WOFF2 files are requested but are not included in the Python package.

PS. The path to the fonts are also affected by problems similar to #35 to fully function. One step at a time.